### PR TITLE
CMR-Hotfix: Support new gesdesc work

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,7 @@
     [gov.nasa.earthdata/cmr-authz "0.1.1-SNAPSHOT"]
     [gov.nasa.earthdata/cmr-exchange-common "0.2.0-SNAPSHOT"]
     [gov.nasa.earthdata/cmr-exchange-query "0.2.0-SNAPSHOT"]
-    [gov.nasa.earthdata/cmr-http-kit "0.1.2-SNAPSHOT"]
+    [gov.nasa.earthdata/cmr-http-kit "0.1.3-SNAPSHOT"]
     [gov.nasa.earthdata/cmr-jar-plugin "0.1.0-SNAPSHOT"]
     [gov.nasa.earthdata/cmr-mission-control "0.1.0-SNAPSHOT"]
     [gov.nasa.earthdata/cmr-site-templates "0.1.0-SNAPSHOT"]
@@ -238,5 +238,7 @@
       ["ubercompile"]
       ["uberjar"]]
     ;; Application
+    "run" ["with-profile" "+system,+security" "run"]
+    "trampoline" ["with-profile" "+system,+security" "trampoline"]
     "start-cmr-opendap"
       ["trampoline" "run"]})

--- a/resources/config/cmr-opendap/config.edn
+++ b/resources/config/cmr-opendap/config.edn
@@ -62,7 +62,7 @@
      :heartbeat 200 ; milliseconds
      }}
  :logging {
-   :level :trace
+   :level :debug
    :nss [cmr org.httpkit]
    :color false}
  :mission-control {

--- a/src/cmr/opendap/app/middleware.clj
+++ b/src/cmr/opendap/app/middleware.clj
@@ -39,9 +39,10 @@
       (log/debug "Got site-routes:" (vec site-routes))
       (let [api-version (request/accept-api-version system req)
             api-routes (main-api-routes-fn system api-version)
-            _ (log/debug "Got plugins-api-routes:" (vec plugins-api-routes))
-            _ (log/debug "Got api-routes:" (vec api-routes))
+            _ (log/trace "Got plugins-api-routes:" (vec plugins-api-routes))
+            _ (log/trace "Got api-routes:" (vec api-routes))
             routes (concat site-routes plugins-api-routes api-routes)
+            _ (log/trace "Got assembled routes:" (vec routes))
             handler (ring/ring-handler (ring/router routes opts))]
         (log/debug "API version:" api-version)
         (log/debug "Made routes:" (vec routes))

--- a/src/cmr/opendap/components/config.clj
+++ b/src/cmr/opendap/components/config.clj
@@ -103,19 +103,28 @@
 (def http-entry-point-fn httpd-config/http-entry-point-fn)
 (def http-assets httpd-config/http-assets)
 (def http-docs httpd-config/http-docs)
-(def http-port httpd-config/http-port)
 (def http-index-dirs httpd-config/http-index-dirs)
 (def http-replace-base-url httpd-config/http-replace-base-url)
 (def http-rest-docs-base-url-template httpd-config/http-rest-docs-base-url-template)
 (def http-rest-docs-outdir httpd-config/http-rest-docs-outdir)
 (def http-rest-docs-source httpd-config/http-rest-docs-source)
 (def http-skip-static httpd-config/http-skip-static)
-(def http-base-url httpd-config/http-base-url)
 (def streaming-heartbeat httpd-config/streaming-heartbeat)
 (def streaming-timeout httpd-config/streaming-timeout)
 (def api-routes httpd-config/api-routes)
 (def site-routes httpd-config/site-routes)
 (def default-page-title httpd-config/default-page-title)
+
+;; Overrides of the HTTPD config component
+(defn http-port
+  [system]
+  (or (get-in (get-cfg system) [:cmr :opendap :port])
+      (httpd-config/http-port system)))
+
+(defn http-base-url
+  [system]
+  (or (get-in (get-cfg system) [:cmr :opendap :relative :root :url])
+      (httpd-config/http-base-url system)))
 
 ;; From the common config component
 (def log-color? config/log-color?)

--- a/src/cmr/opendap/config.clj
+++ b/src/cmr/opendap/config.clj
@@ -60,14 +60,16 @@
   (->> (#'environ/read-system-props)
        (map normalize-prop)
        (remove nil?)
-       (reduce nest-vars {})))
+       (reduce nest-vars {})
+       ((fn [x] (log/trace "props-data:" x) x))))
 
 (defn env-data
   []
   (->> (#'environ/read-system-env)
        (map normalize-env)
        (remove nil?)
-       (reduce nest-vars {})))
+       (reduce nest-vars {})
+       ((fn [x] (log/trace "env-data:" x) x))))
 
 (defn data
   []

--- a/src/cmr/opendap/results/errors.clj
+++ b/src/cmr/opendap/results/errors.clj
@@ -53,7 +53,7 @@
 
 (def no-matching-service-pattern
   (str "There was a problem creating URLs from granule file data: couldn't "
-       "match default service pattern %s to service %s."))
+       "match any default service patterns (i.e.: %s) to service %s."))
 
 (def granule-metadata
   "There was a problem extracting granule metadata.")


### PR DESCRIPTION
There is a new regex check we have to do, until the medium-term (and then later, long-term) solutions for source-data to opendap data URL mappings are in place: we have to support GES-DESC's current efforts to test a roll-out. This change does that.